### PR TITLE
Fix js file path in `index.html`

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <title>TicTacToe</title>
 
     <link href="public/index.css" type="text/css" rel="stylesheet" />
-    <script src="public/game.js"></script>
+    <script src="public/main.js"></script>
   </head>
   <body>
     <div id="app">


### PR DESCRIPTION
The compiled js file is put as `public/main.js` by `webpack.config.js`. So I guess the js file path in `index.html` should be `public/main.js` instead of `public/game.js`.

src/webpack.config.js
```js:
  output: {
    filename: 'main.js',
    path: path.resolve(__dirname, '../public')
  }
```
https://github.com/githubtraining/using-github-actions-for-ci-template/blob/main/src/webpack.config.js#L11

Please confirm it.

Best regards.